### PR TITLE
Production url set instead test url

### DIFF
--- a/pay_process.php
+++ b/pay_process.php
@@ -94,7 +94,7 @@ if(isset($_POST['paIndicator'])){
     //$transRequestXml->transactionRequest->cardholderAuthentication->addChild('cardholderAuthenticationValue',$_POST['paValue']);
 }
 
-$url="https://apitest.authorize.net/xml/v1/request.api";
+$url="https://api.authorize.net/xml/v1/request.api";
 
 //print_r($transRequestXml->asXML());
 


### PR DESCRIPTION
The testing url was being used, and this caused problems when trying to process real payments.

This will solve issue 15: https://github.com/dualcube/moodle-enrol_authorizedotnet/issues/15