### PR TITLE
Fix incorrect variable usage for error message in order_status

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -274,7 +274,7 @@ class moodle_enrol_authorizedotnet_external extends external_api {
         }
         $result = array();
         if($order_status == 'error'){
-            $result['status'] = $error_msg;
+            $result['status'] = $status_msg;
         }
         else{
             $result['status'] = $order_status;


### PR DESCRIPTION
The error message was not displayed when payment submission failed. I changed the variable from `error_msg` to `status_msg` to show users the error message.