### PR TITLE
Fixed stripping leading zeros bug

### DIFF
--- a/enrolment_form.php
+++ b/enrolment_form.php
@@ -87,7 +87,7 @@ class enrol_authorizedotnet_form extends moodleform {
         // Card code (CVV).
         $mform->addElement('text', 'cardcode', get_string('cardcode', 'enrol_authorizedotnet'),
         ['size' => '20', 'maxlength' => '3', 'placeholder' => get_string('cardcodeplaceholder', 'enrol_authorizedotnet'),'class'=>'inputfeild']);
-        $mform->setType('cardcode', PARAM_INT);
+        $mform->setType('cardcode', PARAM_TEXT);
         $mform->addRule('cardcode', get_string('required'), 'required', null, 'client');
         // Billing information header.
         $mform->addElement('html', '<div><h6>'.get_string('billinginfo', "enrol_authorizedotnet").'</h6></div>', );


### PR DESCRIPTION
`PARAM_INT` casts the input to an integer, which strips leading zeroes. If a customer enters a card code that begins with a 0, it is automatically trimmed. For example, a card code of `012` becomes `12` when the form is submitted. This can cause transaction failures. I suggest using `PARAM_TEXT` instead of `PARAM_INT` so the input is treated as a string and retains the leading zeroes.