### PR TITLE
Fix card code to support 4 digits

### DIFF
--- a/enrolment_form.php
+++ b/enrolment_form.php
@@ -86,7 +86,7 @@ class enrol_authorizedotnet_form extends moodleform {
         $mform->addRule('expyear', get_string('required'), 'required', null, 'client');
         // Card code (CVV).
         $mform->addElement('text', 'cardcode', get_string('cardcode', 'enrol_authorizedotnet'),
-        ['size' => '20', 'maxlength' => '3', 'placeholder' => get_string('cardcodeplaceholder', 'enrol_authorizedotnet'),'class'=>'inputfeild']);
+        ['size' => '20', 'maxlength' => '4', 'placeholder' => get_string('cardcodeplaceholder', 'enrol_authorizedotnet'),'class'=>'inputfeild']);
         $mform->setType('cardcode', PARAM_TEXT);
         $mform->addRule('cardcode', get_string('required'), 'required', null, 'client');
         // Billing information header.


### PR DESCRIPTION
Whereas most card codes are only 3 digits, some like AmEx use 4 digits. By increasing the card code to allow 4 digits, AmEx cards are supported.

Please see documentation on American Express website pointing out that their codes may use 4 digits here:
https://www.americanexpress.com/en-us/credit-cards/credit-intel/what-is-cvv/  

Thanks again for this plugin!
